### PR TITLE
(#1709179) journald: fix accuracy of watchdog timer event

### DIFF
--- a/src/journal/journald-server.c
+++ b/src/journal/journald-server.c
@@ -1686,7 +1686,7 @@ static int server_connect_notify(Server *s) {
         if (sd_watchdog_enabled(false, &s->watchdog_usec) > 0) {
                 s->send_watchdog = true;
 
-                r = sd_event_add_time(s->event, &s->watchdog_event_source, CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + s->watchdog_usec/2, s->watchdog_usec*3/4, dispatch_watchdog, s);
+                r = sd_event_add_time(s->event, &s->watchdog_event_source, CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + s->watchdog_usec/2, s->watchdog_usec/4, dispatch_watchdog, s);
                 if (r < 0)
                         return log_error_errno(r, "Failed to add watchdog time event: %m");
         }


### PR DESCRIPTION
Adding 3/4th of the watchdog frequency as accuracy on top of 1/2 of the watchdog frequency means we might end up at 5/4th of the frequency which means we might miss the message from time to time.

Maybe fixes #1804

(cherry picked from commit 4de2402b603ea2f518f451d06f09e15aeae54fab)

Resolves: [#1709179](https://bugzilla.redhat.com/show_bug.cgi?id=1709179)